### PR TITLE
Add cronjob for binary builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - "**.rs"
       - "Cargo.toml"
+  schedule:
+    - cron: '0 0 1 * *'  # once a month
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
In this PR I have added a cron-job for `build.yml` that runs once a month.

Reasons:
1. After 3 months, artifacts expire
2. So if you don't make any new commits every few months, binary artifacts will not be downloadable

If you choose to accept this PR, please add a `hacktoberfest-accepted` label so this counts as a hacktober PR.